### PR TITLE
Create functioning live server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 bower_components/
 *.log
 
+www/
 build/
 dist/
 bundles

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "nodemon server/server.js",
-    "startAll": "./node_modules/.bin/webpack --watch & nodemon server/server.js & clear",
+    "startAll": "npm-run-all --parallel start build:watch",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build:watch": "webpack --watch",
     "seed": "node server/db/seed.js"

--- a/package.json
+++ b/package.json
@@ -23,28 +23,27 @@
   "homepage": "https://github.com/OrderlyPhoenix/OrderlyPhoenix#readme",
   "devDependencies": {
     "babel-core": "^6.23.1",
+    "babel-loader": "^6.4.0",
+    "babel-preset-latest": "^6.22.0",
+    "babel-preset-react": "^6.23.0",
+    "browser-sync": "^2.18.8",
     "browser-sync-webpack-plugin": "^1.1.4",
     "css-loader": "^0.26.4",
     "nodemon": "^1.11.0",
     "npm-run-all": "^4.0.2",
-    "style-loader": "^0.13.2"
+    "style-loader": "^0.13.2",
+    "webpack": "^2.2.1",
+    "webpack-body-parser": "^1.11.110",
+    "webpack-dev-middleware": "^1.10.1"
   },
   "dependencies": {
     "axios": "^0.15.3",
-    "babel-core": "^6.23.1",
-    "babel-loader": "^6.4.0",
-    "babel-preset-latest": "^6.22.0",
-    "babel-preset-react": "^6.23.0",
     "body-parser": "^1.17.1",
-    "browser-sync": "^2.18.8",
     "express": "^4.15.2",
     "express-session": "^1.15.1",
     "mongoose": "^4.8.6",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "react-router": "^3.0.2",
-    "webpack": "^2.2.1",
-    "webpack-body-parser": "^1.11.110",
-    "webpack-dev-middleware": "^1.10.1"
+    "react-router": "^3.0.2"
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -11,7 +11,7 @@ app.use('/bundles', express.static(__dirname + '/../bundles'));
 
 app.use('/api', router);
 
-var port = process.env.port || 8080;
+var port = process.env.port || 3100;
 
 const server = app.listen(port, function() {
   console.log(`Orderly Phoenix listening at ${port}`);


### PR DESCRIPTION
Browser sync automatically runs, but only on a server whose port is 3100. So I changed this be setting the server to the port 3100.

However, when you actually run the file, you don't run on port 3100. You run on port 3000 - 'localhost:3000'.

Modify the startAll command to be npm-run-all '--parallel'. '--parallel' is important because npm commands normally wait for the previous command to finish before starting. '--parallel' gets them to run at the same time.

We were running into an error because Webpack would wait for Nodemon to finish, and it would throw an error because Nodemon would never finish.

Also added /www to .gitignore.

Finally, moved Webpack and assorted dependencies to development dependencies in the 'package.json' That was kind of annoying me.